### PR TITLE
feat(shortcuts-manager): improve rising-edge triggers

### DIFF
--- a/src/main/java/repositories/ShortcutsFileParser.java
+++ b/src/main/java/repositories/ShortcutsFileParser.java
@@ -3,7 +3,6 @@ import java.util.ArrayList;
 import entities.shortcut.Shortcut;
 import entities.shortcut.ShortcutClickType;
 import entities.shortcut.ShortcutKeyEvent;
-import entities.shortcut.ShortcutKeyId;
 import entities.shortcutfile.ShortcutFile;
 import entities.shortcutfile.ShortcutFileAction;
 
@@ -110,8 +109,6 @@ public class ShortcutsFileParser {
                 continue;
             }
             String[] splittedByPlusChar = splittedBySpace[index].split("\\+");
-            // TODO: Em tese eu deveria fazer o trigger dar o match apenas na borda de
-            // subida, mas não sei exatamente como fazer isso
             for (int j = 0; j < splittedByPlusChar.length; j++) {
                 Integer keyCode = this.keyAdapter.parseStringToKeyId(splittedByPlusChar[j]);
                 keyEvent.add(new ShortcutKeyEvent(keyCode, ShortcutClickType.DOWN));

--- a/src/main/java/views/cli/ShortcutRunnerFrame.java
+++ b/src/main/java/views/cli/ShortcutRunnerFrame.java
@@ -18,7 +18,7 @@ public class ShortcutRunnerFrame implements IFrame {
             );
         } catch (Exception e) {}
         if (shortcutsManager != null) {
-            shortcutsManager.initListenner();
+            shortcutsManager.init();
         }
         AnsiUtil.clear();
         AnsiUtil.setGoldColor();
@@ -34,7 +34,7 @@ public class ShortcutRunnerFrame implements IFrame {
         AnsiUtil.setPurpleColor();
         String in = scan.next();
         if (shortcutsManager != null) {
-            shortcutsManager.finishListenner();
+            shortcutsManager.stop();
         }
         if (in.equals("1")) {
             AnsiUtil.clear();


### PR DESCRIPTION
## Motivação

Na PR https://github.com/PauloIVM/dummy-copilot-2.0/pull/2 eu adicionei uns testes automatizados. Um deles quebrava e indicava um erro no código, conforme o print abaixo. Vou explicar melhor o erro e a solução.

![image](https://github.com/PauloIVM/dummy-copilot-2.0/assets/59659732/e94201c3-2f50-4210-bbec-0bec635316ef)

O que esse teste acusa é que um atalho no `shortcuts.config.json` com teclas simultâneas, o user precisará soltar as teclas em uma ordem específica, do contrário não funcionará.

Por exemplo, vamos supor q no json tenhamos o atalho:

```json
    {
        "trigger": "ctrl+space",
        "actions": [{ "type": "sequence", "keys": "backspace" }, { "type": "paste", "content": "FOO" }]
    }
```

Então, do jeito q estava, o usuário precisaria teclar `(ctrl-down) (space-down) (ctrl-up) (space-up)` para funcionar... se ele teclasse `(ctrl-down) (space-down) (space-up) (ctrl-up)`, já não iria funcionar. Isso é um ruim, pq em geral os atalhos não levam em conta a ordem de release das teclas, apenas a ordem em que foram pressionadas, e pode gerar confusão no user deixando ele sem entender pq o atalho não está funcionando.

Ainda assim, quando falamos de um atalho de combinação de teclas, as teclas devem ser pressionadas na ordem correta, e isso está sendo coberto nos testes automatizados.

## Solução

Eu criei um array que identifica bordas de descida de um atalho em que mais de uma tecla é pressionada. Esse array é um array de booleans; daí os elementos que forem uma borda de descida, é só eu considerar como se fosse uma `sameKey`, pois consigo assegurar que houve uma borda de subida que já deu o match e eu descarto a conferência especificamente na borda de descida.

Por exemplo, vamos supor um conjunto de teclas que sejam pressionadas da seguinte forma:

```
[DOWN, DOWN, UP, UP, DOWN, UP, DOWN, DOWN, UP, UP]
```

Então, elas deverão gerar o seguinte array:

```
[false, false, true, true, false, false, false, false, true, true]
```